### PR TITLE
Dev Container Windows Fix

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
     "dockerComposeFile": "../docker-compose-with-git.yml",
     "service": "robosub-ros2",
     "workspaceFolder": "/root/dev/robosub-ros2",
-    "initializeCommand": "bash ./docker-build.sh",
+    "initializeCommand": "bash ./docker-build.sh skip-wsl",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Duke Robotics Club - RoboSub ROS 2.
+# Duke Robotics Club - RoboSub ROS 2
 The Duke Robotics Club is a student organization of [Duke University](https://duke.edu) that develops Autonomous Underwater Vehicles (AUVs) for the [RoboSub](https://robosub.org) competition. Check out [our website](https://duke-robotics.com) for more information about our club and projects.
 
 This repository contains all code required for running and testing our AUVs. The code is built on the [Robot Operating System (ROS) 2](https://github.com/ros2) framework. We use the [Jazzy Jalisco](https://docs.ros.org/en/jazzy) distribution of ROS 2.
@@ -80,6 +80,10 @@ Make sure you have Docker running on your machine. Then, follow the instructions
 If you're using VS Code and have the Dev Containers extension installed:
 
 1. Open the repo in VS Code.
+2. **Windows users only:** Open a Git Bash terminal in VS Code and run the following command to start the Docker container (make sure your working directory is the repository root):
+    ```bash
+    ./docker-build.sh
+    ```
 2. Open the Command Palette (`Ctrl/Cmd + Shift + P`).
 3. Run the `Dev Containers: Reopen in Container` command.
 4. Wait for the container to finish building.
@@ -97,6 +101,13 @@ If you're using VS Code and have the Dev Containers extension installed:
     - If you set `NO_GIT=false` in the `.env` file, you can make signed commits and pull/push changes to remote from within the container.
     - You must build the packages in the container before running the code. See the [Build Packages](#build-packages) section for more information.
 6. When you're done, simply close the VS Code window to stop the container.
+
+> [!IMPORTANT]
+> **Windows Users:**
+>
+> Windows users **must** execute the `docker-build.sh` script via Git Bash _prior_ to reopening the VS Code window in the Dev Container. This script sets up the container to allow you to sign commits, pull, and push changes to the remote repository.
+>
+> Do **not** rebuild the container through the Dev Containers extension in VS Code. This will cause the container to lose the necessary configuration to sign commits. Instead execute `docker-build.sh` _locally_ (outside the container) in Git Bash to rebuild the container.
 
 #### Without VS Code Dev Containers
 If you're **not** using VS Code or do **not** have the Dev Containers extension installed:

--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ If you're using VS Code and have the Dev Containers extension installed:
 > Windows users **must** execute the `docker-build.sh` script via Git Bash _prior_ to reopening the VS Code window in the Dev Container. This script sets up the container to allow you to sign commits, pull, and push changes to the remote repository.
 >
 > Do **not** rebuild the container through the Dev Containers extension in VS Code. This will cause the container to lose the necessary configuration to sign commits. Instead execute `docker-build.sh` _locally_ (outside the container) in Git Bash to rebuild the container.
+>
+> If you get the error `onboard2 is already in use`, run the following command in Git Bash to remove the existing container:
+> ```bash
+> docker rm -f onboard2
+> ```
+> Then, run the `docker-build.sh` script again.
 
 #### Without VS Code Dev Containers
 If you're **not** using VS Code or do **not** have the Dev Containers extension installed:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Duke Robotics Club - RoboSub ROS 2
+# Duke Robotics Club - RoboSub ROS 2.
 The Duke Robotics Club is a student organization of [Duke University](https://duke.edu) that develops Autonomous Underwater Vehicles (AUVs) for the [RoboSub](https://robosub.org) competition. Check out [our website](https://duke-robotics.com) for more information about our club and projects.
 
 This repository contains all code required for running and testing our AUVs. The code is built on the [Robot Operating System (ROS) 2](https://github.com/ros2) framework. We use the [Jazzy Jalisco](https://docs.ros.org/en/jazzy) distribution of ROS 2.

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Check if the first argument is "skip-wsl" and if the script is running in WSL
+if [[ "$1" == "skip-wsl" && -f /proc/sys/fs/binfmt_misc/WSLInterop ]]; then
+    echo "'skip-wsl' is specified and the script is running in WSL. Exiting..."
+    exit 0
+fi
+
 # Load variables from .env file
 set -o allexport
 source .env

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Check if the first argument is "skip-wsl" and if the script is running in WSL
+# This is used by the Dev Container to avoid starting the container via this script when running on Windows
 if [[ "$1" == "skip-wsl" && -f /proc/sys/fs/binfmt_misc/WSLInterop ]]; then
     echo "'skip-wsl' is specified and the script is running in WSL. Exiting..."
     exit 0


### PR DESCRIPTION
Added arg `skip-wsl` to `docker-build.sh` that bypasses the script when the Dev Container is started on Windows (inside WSL). Updated `README.md` with instructions for Windows users.