### PR TITLE
Minor Fixes

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -134,6 +134,10 @@ If you're **not** using VS Code or do **not** have the Dev Containers extension 
     ```bash
     docker exec -ti -w /root/dev/robosub-ros2 onboard2 bash
     ```
+    - If you're running this command in Git Bash on Windows, add an extra `/` before `/root`:
+        ```bash
+        docker exec -ti -w //root/dev/robosub-ros2 onboard2 bash
+        ```
 4. Now, you're ready to start developing!
     - Any changes you make in the repository on your host machine are reflected in the `/root/dev/robosub-ros2` directory in the Docker container.
     - If you set `NO_GIT=false` in the `.env` file, you can make signed commits and pull/push changes to remote from within the container.

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -8,6 +8,12 @@ if [[ "$1" == "skip-wsl" && -f /proc/sys/fs/binfmt_misc/WSLInterop ]]; then
     exit 0
 fi
 
+# Get the path to the directory containing this script, which is the robosub-ros2 repository root
+robosub_ros2_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" || exit ; pwd -P )
+
+# Change to the repository root directory
+cd "$robosub_ros2_path" || exit
+
 # Load variables from .env file
 set -o allexport
 source .env

--- a/onboard/src/offboard_comms/CMakeLists.txt
+++ b/onboard/src/offboard_comms/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(offboard_coms)
+project(offboard_comms)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/onboard/src/offboard_comms/package.xml
+++ b/onboard/src/offboard_comms/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>offboard_coms</name>
+  <name>offboard_comms</name>
   <version>0.0.0</version>
   <description>TODO: Package description</description>
   <maintainer email="root@todo.todo">root</maintainer>


### PR DESCRIPTION
- Added `docker exec` command to use in Git Bash on Windows.
- Made `docker-build.sh` script work even if it's run from outside the repository root.
- Change `offboard_coms` to `offboard_comms` in config files.