### PR TITLE
Fix Sensors Status Panel Flickering

### DIFF
--- a/foxglove/extensions/sensors-status-panel/src/SensorsStatusPanel.tsx
+++ b/foxglove/extensions/sensors-status-panel/src/SensorsStatusPanel.tsx
@@ -116,7 +116,7 @@ function SensorsStatusPanel({ context }: { context: PanelExtensionContext }): Re
             const connectStatus = { ...prevState.connectStatus };
             for (const sensor of seenSensors) {
               if (renderState.currentTime?.sec != undefined) {
-                sensorsTime[sensor] = renderState.currentTime?.sec;
+                sensorsTime[sensor] = renderState.currentTime.sec;
                 connectStatus[sensor] = true;
               }
             }


### PR DESCRIPTION
Fix correctness issue with sensors status panel where some sensors were showing as down even though they were publishing.