### PR TITLE
Fix foxglove messages build issue

### DIFF
--- a/foxglove/shared/defs/src/generateRosTsGeneratorConfig.ts
+++ b/foxglove/shared/defs/src/generateRosTsGeneratorConfig.ts
@@ -21,9 +21,10 @@ export function generateRosTsGeneratorConfig(
     .map((name) => join(rosSharePath, name))
     .filter((path) => statSync(path).isDirectory());
 
-  // Include every package that actually defines messages or services, i.e. one with a 'msg' or 'srv' directory.
   const filteredDirectories = allDirectories.filter(
-    (dir) => existsSync(join(dir, "msg")) || existsSync(join(dir, "srv")),
+    (dir) =>
+      (dir.endsWith("_srvs") || dir.endsWith("_msgs") || dir.endsWith("_interfaces")) &&
+      (existsSync(join(dir, "msg")) || existsSync(join(dir, "srv"))),
   );
 
   // Create the JSON configuration object

--- a/foxglove/shared/defs/src/generateRosTsGeneratorConfig.ts
+++ b/foxglove/shared/defs/src/generateRosTsGeneratorConfig.ts
@@ -1,4 +1,4 @@
-import { readdirSync, statSync, writeFileSync } from "fs";
+import { existsSync, readdirSync, statSync, writeFileSync } from "fs";
 import { join } from "path";
 
 /**
@@ -21,8 +21,10 @@ export function generateRosTsGeneratorConfig(
     .map((name) => join(rosSharePath, name))
     .filter((path) => statSync(path).isDirectory());
 
-  // Filter directories to only include those ending in '_srvs' or '_msgs'
-  const filteredDirectories = allDirectories.filter((dir) => dir.endsWith("_srvs") || dir.endsWith("_msgs"));
+  // Include every package that actually defines messages or services, i.e. one with a 'msg' or 'srv' directory.
+  const filteredDirectories = allDirectories.filter(
+    (dir) => existsSync(join(dir, "msg")) || existsSync(join(dir, "srv")),
+  );
 
   // Create the JSON configuration object
   const outputData = {


### PR DESCRIPTION
Background: we generate our ROS TypeScript types from source (whatever ROS is currently installed in the container) whenever we do `fox build`. For more active frontend teams, the better pattern would probably be to commit these types and have someone rebuild/review the updated types regularly. However, I automated this process during the ROS 2 migration since we don't have an active frontend team to do this. This means that if ROS adds new message definitions, the build may occasionally break and you may have to do a fix like this...